### PR TITLE
Use shared renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,57 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "automergeType": "branch",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
-      "matchStrings": [
-        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
-      ],
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble&components=main,universe,restricted,multiverse&binaryArch=amd64"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
-      "matchStrings": [
-        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
-      ],
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-security&components=main,universe,restricted,multiverse&binaryArch=amd64"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
-      "matchStrings": [
-        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
-      ],
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-updates&components=main,universe,restricted,multiverse&binaryArch=amd64"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
-      "matchStrings": [
-        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
-      ],
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-backports&components=main,universe,restricted,multiverse&binaryArch=amd64"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
-      "matchStrings": ["ARG HADOLINT_VERSION=(?<currentValue>\\S+)"],
-      "depNameTemplate": "hadolint/hadolint",
-      "datasourceTemplate": "github-releases"
-    }
-  ]
+  "extends": ["github>ScottG489/renovate-config"],
+  "automergeType": "branch"
 }


### PR DESCRIPTION
## Summary
- Replace inline renovate configuration with shared preset from `ScottG489/renovate-config`
- Remove duplicated rules (extends, packageRules, customManagers) that are now inherited from the shared config
- Keep only repo-specific configuration that isn't in the shared preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)